### PR TITLE
Define required interfaces and sockets bindings according to Common Criteria

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -23,6 +23,28 @@
                 driver_module_name: org.postgresql
                 driver_class_name: org.postgresql.Driver
                 driver_xa_datasource_class_name: org.postgresql.xa.PGXADataSource
+          - interfaces:
+              - name: internal
+                inet_address: '127.0.0.1'
+              - name: public
+                inet_address: '127.0.0.1'
+          - standard_sockets:
+              - name: ajp
+                interface: internal
+                port: '8009'
+              - name: http
+                interface: public
+                port: '8080'
+              - name: https
+                interface: public
+                port: '8443'
+              - name: management-http
+                interface: internal
+                port: 9990
+              - name: management-https
+                interface: internal
+                port: 9993
+
 
 - name: "Check compliance of EAP setup with Common Criteria"
   hosts: jboss


### PR DESCRIPTION
@sabre1041 Interface and socket bindings worked (almost) like a charm. I needed to fixup something in the Ansible Collection (missing commas to allow to define several interface & socket binding), but it's done now:

https://github.com/wildfly-extras/ansible_collections_jcliff/commit/200a4e2cc521c241273e79da3b0bc13668aa6a8a